### PR TITLE
Wrong dts name

### DIFF
--- a/Pi4-64-beta/install.sh
+++ b/Pi4-64-beta/install.sh
@@ -7,7 +7,7 @@ ROTATE_NAME="ctp40-rotate"
 BINARY_PATH="/usr/bin"
 OVERLAY_PATH="/boot/overlays"
 OVERLAY_NAME="ctp40.dtbo"
-OVERLAY_SRC="ctp40-overlay.dts"
+OVERLAY_SRC="ctp40.dts"
 
 CONFIG="/boot/config.txt"
 


### PR DESCRIPTION
Hi,

The dts filename is wrong in the Pi4-64-beta install script.

Regards,
Orel