### PR TITLE
Different reboots leads to different i2c address for the touch module

### DIFF
--- a/Pi4-64-beta/src/ctp40.dts
+++ b/Pi4-64-beta/src/ctp40.dts
@@ -45,9 +45,19 @@
             /* needed to avoid dtc warning */
             #address-cells = <1>;
             #size-cells = <0>;
-            ft6236: ft6236@14 {
+            ft6236_14: ft6236@14 {
                 compatible = "goodix,gt911";
                 reg = <0x14>;
+                interrupt-parent = <&gpio>;
+                interrupts = <27 2>;
+                touchscreen-size-x = <480>;
+                touchscreen-size-y = <800>;
+                touchscreen-x-mm = <51>;
+                touchscreen-y-mm = <85>;
+            };
+            ft6236_5d: ft6236@5d {
+                compatible = "goodix,gt911";
+                reg = <0x5d>;
                 interrupt-parent = <&gpio>;
                 interrupts = <27 2>;
                 touchscreen-size-x = <480>;
@@ -58,26 +68,47 @@
         };
     };
     fragment@4 {
-        target = <&ft6236>;
+        target = <&ft6236_14>;
         __dormant__ {
             touchscreen-inverted-x;
         };
     };
     fragment@5 {
-        target = <&ft6236>;
+        target = <&ft6236_14>;
         __overlay__ {
             touchscreen-inverted-y;
         };
     };
     fragment@6 {
-        target = <&ft6236>;
+        target = <&ft6236_14>;
+        __overlay__ {
+            touchscreen-swapped-x-y;
+        };
+    };
+    fragment@7 {
+        target = <&ft6236_5d>;
+        __dormant__ {
+            touchscreen-inverted-x;
+        };
+    };
+    fragment@8 {
+        target = <&ft6236_5d>;
+        __overlay__ {
+            touchscreen-inverted-y;
+        };
+    };
+    fragment@9 {
+        target = <&ft6236_5d>;
         __overlay__ {
             touchscreen-swapped-x-y;
         };
     };
     __overrides__ {
-        touchscreen-inverted-x = <0>,"+4";
-        touchscreen-inverted-y = <0>,"-5";
-        touchscreen-swapped-x-y = <0>,"-6";
+        touchscreen-inverted-x = <0>,"+4",
+                                 <0>,"+7";
+        touchscreen-inverted-y = <0>,"-5",
+                                 <0>,"-8";
+        touchscreen-swapped-x-y = <0>,"-6",
+                                  <0>,"-9";
     };
 };


### PR DESCRIPTION
Hi,

Sometimes at some boots, the touch feature doesn't work.
It seems the touch module has 2 different addresses on the I2C bus (checked with i2cdetect on a raspberry 4 + screen).

## Touch module ok
Log :
```
/var/log/kern.log:4970:Mar  1 18:24:53 myhostname kernel: [    7.343479] Goodix-TS 22-0014: supply AVDD28 not found, using dummy regulator
/var/log/kern.log:4971:Mar  1 18:24:53 myhostname kernel: [    7.345024] Goodix-TS 22-0014: supply VDDIO not found, using dummy regulator
/var/log/kern.log:4972:Mar  1 18:24:53 myhostname kernel: [    7.346970] Goodix-TS 22-0014: ID 911, version: 1060
/var/log/kern.log:4973:Mar  1 18:24:53 myhostname kernel: [    7.368357] input: Goodix Capacitive TouchScreen as /devices/platform/i2c@0/i2c-22/22-0014/input/input0
```

I2C address :
```console
username@hostname:~$ i2cdetect -y 22
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- UU -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
70: -- -- -- -- -- -- -- -- 
```

## Touche module ko
Log :
```
/var/log/kern.log:5299:Mar  2 14:33:28 myhostname kernel: [    6.575737] Goodix-TS 22-0014: supply AVDD28 not found, using dummy regulator
/var/log/kern.log:5300:Mar  2 14:33:28 myhostname kernel: [    6.576981] Goodix-TS 22-0014: supply VDDIO not found, using dummy regulator
/var/log/kern.log:5301:Mar  2 14:33:28 myhostname kernel: [    6.577781] Goodix-TS 22-0014: i2c test failed attempt 1: -6
/var/log/kern.log:5303:Mar  2 14:33:28 myhostname kernel: [    6.605411] Goodix-TS 22-0014: i2c test failed attempt 2: -6
/var/log/kern.log:5304:Mar  2 14:33:28 myhostname kernel: [    6.636825] Goodix-TS 22-0014: I2C communication failure: -6
```

I2C address :
```console
username@hostname:~$ i2cdetect -y 22
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
50: -- -- -- -- -- -- -- -- -- -- -- -- -- 5d -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
70: -- -- -- -- -- -- -- -- 
```

I don't know exactly why but there is an interesting discussion here : https://github.com/pimoroni/hyperpixel4/issues/41

Thanks @Gadgetoid for the idea to duplicate the related overlay !